### PR TITLE
added openpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Favicons are ranked by quality (size, format, source) and the best one is return
 The following projects are using the Favicon API:
 
 - [Vemetric](https://vemetric.com) - Simple, yet actionable Web & Product Analytics
+- [OpenPanel](https://openpanel.com?utm_src=vemetric_readme) - Next Generation Web Hosting Panel
 
 Are you using the Favicon API and wanna be listed here? Feel free to file a Pull Request!
 


### PR DESCRIPTION
instead of relying on google favicons, openpanel 1.6.7 allows administrators to define a custom favicon api url: https://dev.openpanel.com/cli/config.html#favicons

Default for new installations is vemetric/favicon-api running on https://favicon-api.openpanel.org/