### PR TITLE
Add MCP Use Inspector to Used by section

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ The following projects are using the Favicon API:
 - [Vemetric](https://vemetric.com) - Simple, yet actionable Web & Product Analytics
 - [Orshot](https://orshot.com/) - Scale your Marketing with Automated Visuals
 - [OpenPanel](https://openpanel.com?utm_src=vemetric_readme) - Next Generation Web Hosting Panel
+- [MCP Use Inspector](https://inspector.mcp-use.com) Modern MCP Inspector with Apps SDK Support
 
 Are you using the Favicon API and wanna be listed here? Feel free to file a Pull Request!
 


### PR DESCRIPTION
First of all thanks for this amazing project!
The [MCP Use Inspector](https://inspector.mcp-use.com) relies on favicon-api hosted at favicon.tools.mcp-use.com to show MCP servers icons in the inspector
<img width="552" height="569" alt="Screenshot 2025-11-20 alle 11 32 50" src="https://github.com/user-attachments/assets/c84305b5-d2d1-4e65-882f-a2014776854d" />
