### PR TITLE
Fix/always add fallback locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run -d \
 ### Single Endpoint
 
 ```
-GET /<domain>&format=<json|image>&size=<number>&type=<png|jpg|svg>&default=<url>
+GET /<domain>&response=<json|image>&size=<number>&format=<png|jpg|webp>&default=<url>
 ```
 
 ### Query Parameters
@@ -105,7 +105,7 @@ curl "http://localhost:3000/github.com"
 **Get favicon metadata as JSON:**
 
 ```bash
-curl "http://localhost:3000/github.com&format=json"
+curl "http://localhost:3000/github.com&response=json"
 ```
 
 **Resize favicon to 64x64:**
@@ -117,7 +117,7 @@ curl "http://localhost:3000/github.com&size=64"
 **Convert to PNG:**
 
 ```bash
-curl "http://localhost:3000/github.com&type=png&size=128"
+curl "http://localhost:3000/github.com&format=png&size=128"
 ```
 
 **With custom fallback:**

--- a/src/lib/favicon-finder.ts
+++ b/src/lib/favicon-finder.ts
@@ -35,15 +35,9 @@ export async function findFavicons(
     const parsedUrl = new URL(targetUrl);
     baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
   } catch {
-    // If URL parsing fails, try to construct from input
-    baseUrl = targetUrl.startsWith('http') ? targetUrl : `https://${targetUrl}`;
-    try {
-      const parsedUrl = new URL(baseUrl);
-      baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
-    } catch {
-      // Last resort: assume https
-      baseUrl = `https://${url.replace(/^https?:\/\//, '')}`;
-    }
+    // URL parsing failed - construct best-effort base URL from hostname
+    const hostname = url.replace(/^https?:\/\//, '').split('/')[0];
+    baseUrl = `https://${hostname}`;
   }
 
   try {

--- a/src/lib/favicon-finder.ts
+++ b/src/lib/favicon-finder.ts
@@ -28,6 +28,23 @@ export async function findFavicons(
 
   // Ensure URL has protocol
   const targetUrl = url.startsWith('http') ? url : `https://${url}`;
+  
+  // Parse base URL - we'll use this for fallbacks even if HTML fetch fails
+  let baseUrl: string;
+  try {
+    const parsedUrl = new URL(targetUrl);
+    baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+  } catch {
+    // If URL parsing fails, try to construct from input
+    baseUrl = targetUrl.startsWith('http') ? targetUrl : `https://${targetUrl}`;
+    try {
+      const parsedUrl = new URL(baseUrl);
+      baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+    } catch {
+      // Last resort: assume https
+      baseUrl = `https://${url.replace(/^https?:\/\//, '')}`;
+    }
+  }
 
   try {
     // Fetch HTML content and get final URL after redirects
@@ -39,23 +56,28 @@ export async function findFavicons(
     // Extract favicons from HTML (only link tags, no OG images)
     favicons.push(...extractFromLinkTags($, finalBaseUrl));
 
-    // Add common fallback locations
-    favicons.push({
-      url: `${finalBaseUrl}/favicon.ico`,
-      source: 'fallback',
-      score: 10,
-    });
-
-    favicons.push({
-      url: `${finalBaseUrl}/apple-touch-icon.png`,
-      source: 'fallback',
-      score: 20,
-    });
+    // Update baseUrl to final URL after redirects for fallbacks
+    baseUrl = finalBaseUrl;
 
     // Try to fetch and parse manifest.json
     const manifestFavicons = await extractFromManifest(finalBaseUrl, config);
     favicons.push(...manifestFavicons);
-  } catch {}
+  } catch {
+    // HTML fetch failed, but we still have baseUrl for fallbacks
+  }
+
+  // Always add common fallback locations (even if HTML fetch failed)
+  favicons.push({
+    url: `${baseUrl}/favicon.ico`,
+    source: 'fallback',
+    score: 10,
+  });
+
+  favicons.push({
+    url: `${baseUrl}/apple-touch-icon.png`,
+    source: 'fallback',
+    score: 20,
+  });
 
   // Add Google's favicon API as last-resort fallback (if enabled)
   if (config.USE_FALLBACK_API) {

--- a/src/lib/favicon-finder.ts
+++ b/src/lib/favicon-finder.ts
@@ -28,7 +28,7 @@ export async function findFavicons(
 
   // Ensure URL has protocol
   const targetUrl = url.startsWith('http') ? url : `https://${url}`;
-  
+
   // Parse base URL - we'll use this for fallbacks even if HTML fetch fails
   let baseUrl: string;
   try {


### PR DESCRIPTION
Thanks for this project. I found a couple of typos in the README and, more importantly, an issue in the detection logic: if the HTML fetch fails, the fallbacks are not checked. In my case, the HTML was correctly not returning since it's an API, but the favicon is still being served, so I wanted it to detect the icon.
This PR fixes both issues:
1. Always checks fallback locations (/favicon.ico and /apple-touch-icon.png) even when HTML fetch fails
2. Corrects the README to use response for json/image and format for image format
